### PR TITLE
Add FastAPI backend service

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ LetAgents_DYOR/
 - Environment variables can be set in `backend/.env` or exported before running the server.
 - Start the FastAPI server locally with:
   ```bash
+  pip install -r backend/requirements.txt
   uvicorn backend.main:app --host 0.0.0.0 --port 8000
-  ```
 - Mobile code lives under `mobile/` and uses Flutter 3.x.
 - SQLite is used by default; set Oracle DB credentials in `.env` to use Autonomous DB.
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ LetAgents_DYOR/
 - Contributions are welcome! Open issues or submit pull requests.
 - The CLI can still be executed via `python -m cli.main` or you can call `POST /analyze` from the API.
 - Environment variables can be set in `backend/.env` or exported before running the server.
+- Start the FastAPI server locally with:
+  ```bash
+  uvicorn backend.main:app --host 0.0.0.0 --port 8000
+  ```
 - Mobile code lives under `mobile/` and uses Flutter 3.x.
 - SQLite is used by default; set Oracle DB credentials in `.env` to use Autonomous DB.
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,22 @@
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+app = FastAPI()
+
+# Allow all origins for development; restrict in production
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+@app.get("/")
+def read_root():
+    """Health check route."""
+    return {"message": "Backend up"}
+
+# To run locally:
+# uvicorn backend.main:app --host 0.0.0.0 --port 8000

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn


### PR DESCRIPTION
## Summary
- add FastAPI backend under `backend/`
- list FastAPI and Uvicorn in `backend/requirements.txt`
- document how to run the server via uvicorn in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874139936f883208c47a9c56c4bb9ce