### PR TITLE
Implement basic user auth with JWT

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -1,0 +1,20 @@
+import os
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./users.db")
+
+engine = create_engine(
+    DATABASE_URL, connect_args={"check_same_thread": False} if DATABASE_URL.startswith("sqlite") else {}
+)
+
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base = declarative_base()
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,12 +1,18 @@
 import os
 from typing import List, Optional
 
-from fastapi import FastAPI, HTTPException
+import jwt
+from fastapi import FastAPI, HTTPException, Depends, status
+from fastapi.security import OAuth2PasswordBearer
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
+from sqlalchemy.orm import Session
 
 from tradingagents.graph.trading_graph import TradingAgentsGraph
 from tradingagents.default_config import DEFAULT_CONFIG
+from .database import Base, engine, get_db
+from .models import User
+from passlib.context import CryptContext
 
 app = FastAPI()
 
@@ -19,14 +25,40 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-# Read API keys at startup
-OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY")
-FINNHUB_API_KEY = os.environ.get("FINNHUB_API_KEY")
+# Initialize database
+Base.metadata.create_all(bind=engine)
 
-if not OPENAI_API_KEY or not FINNHUB_API_KEY:
-    raise RuntimeError(
-        "OPENAI_API_KEY and FINNHUB_API_KEY must be set as environment variables"
-    )
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+SECRET_KEY = os.environ.get("SECRET_KEY", "change-me")
+ALGORITHM = "HS256"
+
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="login")
+
+
+def get_password_hash(password: str) -> str:
+    return pwd_context.hash(password)
+
+
+def verify_password(password: str, password_hash: str) -> bool:
+    return pwd_context.verify(password, password_hash)
+
+
+def create_access_token(data: dict) -> str:
+    return jwt.encode(data, SECRET_KEY, algorithm=ALGORITHM)
+
+
+def get_current_user(
+    token: str = Depends(oauth2_scheme), db: Session = Depends(get_db)
+) -> User:
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        user_id: int = payload.get("id")
+    except Exception:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+    user = db.query(User).filter(User.id == user_id).first()
+    if not user:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+    return user
 
 
 class AnalyzeRequest(BaseModel):
@@ -38,17 +70,60 @@ class AnalyzeRequest(BaseModel):
     analysts: Optional[List[str]] = None
 
 
+class UserCreate(BaseModel):
+    email: str
+    password: str
+    openai_api_key: str
+    finnhub_api_key: str
+
+
+class UserLogin(BaseModel):
+    email: str
+    password: str
+
+
 @app.get("/")
 def read_root():
     """Health check route."""
     return {"message": "Backend up"}
 
 
+@app.post("/register")
+def register(user: UserCreate, db: Session = Depends(get_db)):
+    if db.query(User).filter(User.email == user.email).first():
+        raise HTTPException(status_code=400, detail="Email already registered")
+    user_obj = User(
+        email=user.email,
+        password_hash=get_password_hash(user.password),
+        openai_api_key=user.openai_api_key,
+        finnhub_api_key=user.finnhub_api_key,
+    )
+    db.add(user_obj)
+    db.commit()
+    db.refresh(user_obj)
+    return {"id": user_obj.id}
+
+
+@app.post("/login")
+def login(credentials: UserLogin, db: Session = Depends(get_db)):
+    user = db.query(User).filter(User.email == credentials.email).first()
+    if not user or not verify_password(credentials.password, user.password_hash):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
+    token = create_access_token({"id": user.id, "email": user.email})
+    return {"token": token}
+
+
 @app.post("/analyze")
-def analyze(request: AnalyzeRequest):
+def analyze(
+    request: AnalyzeRequest, current_user: User = Depends(get_current_user)
+):
     """Run the TradingAgents analysis and return the results."""
 
     try:
+        # Use user-specific API keys for this request
+        os.environ["OPENAI_API_KEY"] = current_user.openai_api_key
+        os.environ["FINNHUB_API_KEY"] = current_user.finnhub_api_key
+
         # Configure graph based on research depth
         config = DEFAULT_CONFIG.copy()
         config["max_debate_rounds"] = request.research_depth

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,11 @@
+from sqlalchemy import Column, Integer, String
+from .database import Base
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, index=True)
+    email = Column(String, unique=True, index=True, nullable=False)
+    password_hash = Column(String, nullable=False)
+    openai_api_key = Column(String, nullable=False)
+    finnhub_api_key = Column(String, nullable=False)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,2 +1,5 @@
 fastapi
 uvicorn
+sqlalchemy
+passlib[bcrypt]
+PyJWT

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,6 @@ rich
 questionary
 langchain_anthropic
 langchain-google-genai
+sqlalchemy
+passlib[bcrypt]
+PyJWT


### PR DESCRIPTION
## Summary
- add SQLAlchemy models and database session
- implement registration and login with hashed passwords
- add JWT auth and per-user API keys
- protect `/analyze` to require a valid token
- update dependencies for auth backend

## Testing
- `python -m pip install -r backend/requirements.txt`
- `python -m pip install -r requirements.txt`
- `python -m py_compile backend/main.py backend/database.py backend/models.py`

------
https://chatgpt.com/codex/tasks/task_e_68742724d6ac8320a88b9de8260faa92