### PR TITLE
Implement analysis history endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ LetAgents_DYOR/
 
 - Contributions are welcome! Open issues or submit pull requests.
 - The CLI can still be executed via `python -m cli.main` or you can call `POST /analyze` from the API.
+- Retrieve past analyses with `GET /history` and view details with `GET /history/{id}`.
 - Environment variables can be set in `backend/.env` or exported before running the server.
 - Start the FastAPI server locally with:
   ```bash

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,5 +1,18 @@
-from sqlalchemy import Column, Integer, String
+from sqlalchemy import Column, Integer, String, Text, ForeignKey
 from .database import Base
+
+
+class AnalysisRecord(Base):
+    """Persist results of each analysis run."""
+
+    __tablename__ = "analysis_records"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"), index=True, nullable=False)
+    ticker = Column(String, nullable=False)
+    date = Column(String, nullable=False)
+    decision = Column(Text, nullable=False)
+    full_report = Column(Text, nullable=False)
 
 class User(Base):
     __tablename__ = "users"


### PR DESCRIPTION
## Summary
- add new `AnalysisRecord` SQLAlchemy model
- store analysis results when `/analyze` is called
- expose `/history` and `/history/{id}` endpoints to read past runs
- document new API usage in the README

## Testing
- `pip install -r backend/requirements.txt`
- `python -m py_compile backend/main.py backend/models.py backend/database.py`


------
https://chatgpt.com/codex/tasks/task_e_68742ae9c7508320a1cec0578bb5c2be