### PR TITLE
Add login/register screens in Flutter app

### DIFF
--- a/mobile/lib/home_screen.dart
+++ b/mobile/lib/home_screen.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+
+class HomeScreen extends StatelessWidget {
+  const HomeScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(child: Text('LetAgentsDYOR Home')),
+    );
+  }
+}

--- a/mobile/lib/login_screen.dart
+++ b/mobile/lib/login_screen.dart
@@ -1,0 +1,113 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+
+import 'home_screen.dart';
+import 'register_screen.dart';
+import 'services/auth_service.dart';
+
+const String backendUrl = 'http://localhost:8000';
+
+class LoginScreen extends StatefulWidget {
+  const LoginScreen({super.key});
+
+  @override
+  State<LoginScreen> createState() => _LoginScreenState();
+}
+
+class _LoginScreenState extends State<LoginScreen> {
+  final _emailController = TextEditingController();
+  final _passwordController = TextEditingController();
+  bool _loading = false;
+  String? _error;
+
+  Future<void> _login() async {
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+
+    try {
+      final response = await http.post(
+        Uri.parse('$backendUrl/login'),
+        headers: {'Content-Type': 'application/json'},
+        body: jsonEncode({
+          'email': _emailController.text,
+          'password': _passwordController.text,
+        }),
+      );
+      if (response.statusCode == 200) {
+        final data = jsonDecode(response.body);
+        await AuthService.saveToken(data['token']);
+        if (!mounted) return;
+        Navigator.of(context).pushReplacement(
+          MaterialPageRoute(builder: (_) => const HomeScreen()),
+        );
+      } else {
+        setState(() {
+          _error = 'Invalid credentials';
+        });
+      }
+    } catch (e) {
+      setState(() {
+        _error = 'Error: $e';
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _loading = false;
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Login')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            TextField(
+              controller: _emailController,
+              decoration: const InputDecoration(labelText: 'Email'),
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _passwordController,
+              decoration: const InputDecoration(labelText: 'Password'),
+              obscureText: true,
+            ),
+            const SizedBox(height: 16),
+            if (_error != null) ...[
+              Text(_error!, style: const TextStyle(color: Colors.red)),
+              const SizedBox(height: 12),
+            ],
+            _loading
+                ? const CircularProgressIndicator()
+                : SizedBox(
+                    width: double.infinity,
+                    child: ElevatedButton(
+                      onPressed: _login,
+                      child: const Text('Login'),
+                    ),
+                  ),
+            TextButton(
+              onPressed: () {
+                Navigator.of(context).push(
+                  MaterialPageRoute(
+                    builder: (_) => const RegisterScreen(),
+                  ),
+                );
+              },
+              child: const Text("Don't have an account? Sign Up"),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1,6 +1,13 @@
 import 'package:flutter/material.dart';
 
-void main() {
+import 'home_screen.dart';
+import 'login_screen.dart';
+import 'register_screen.dart';
+import 'services/auth_service.dart';
+
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await AuthService.loadToken();
   runApp(const LetAgentsDYORApp());
 }
 
@@ -15,19 +22,12 @@ class LetAgentsDYORApp extends StatelessWidget {
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.indigo),
         useMaterial3: true,
       ),
-      home: const HomeScreen(),
-      routes: const {},
-    );
-  }
-}
-
-class HomeScreen extends StatelessWidget {
-  const HomeScreen({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return const Scaffold(
-      body: Center(child: Text('LetAgentsDYOR Home')),
+      home: AuthService.token == null ? const LoginScreen() : const HomeScreen(),
+      routes: {
+        '/login': (_) => const LoginScreen(),
+        '/register': (_) => const RegisterScreen(),
+        '/home': (_) => const HomeScreen(),
+      },
     );
   }
 }

--- a/mobile/lib/register_screen.dart
+++ b/mobile/lib/register_screen.dart
@@ -1,0 +1,120 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+
+import 'login_screen.dart';
+
+const String backendUrl = 'http://localhost:8000';
+
+class RegisterScreen extends StatefulWidget {
+  const RegisterScreen({super.key});
+
+  @override
+  State<RegisterScreen> createState() => _RegisterScreenState();
+}
+
+class _RegisterScreenState extends State<RegisterScreen> {
+  final _emailController = TextEditingController();
+  final _passwordController = TextEditingController();
+  final _openaiKeyController = TextEditingController();
+  final _finnhubKeyController = TextEditingController();
+  bool _loading = false;
+  String? _error;
+  String? _success;
+
+  Future<void> _register() async {
+    setState(() {
+      _loading = true;
+      _error = null;
+      _success = null;
+    });
+
+    try {
+      final response = await http.post(
+        Uri.parse('$backendUrl/register'),
+        headers: {'Content-Type': 'application/json'},
+        body: jsonEncode({
+          'email': _emailController.text,
+          'password': _passwordController.text,
+          'openai_api_key': _openaiKeyController.text,
+          'finnhub_api_key': _finnhubKeyController.text,
+        }),
+      );
+      if (response.statusCode == 200) {
+        setState(() {
+          _success = 'Registration successful. Please log in.';
+        });
+      } else {
+        setState(() {
+          _error = 'Failed to register';
+        });
+      }
+    } catch (e) {
+      setState(() {
+        _error = 'Error: $e';
+      });
+    } finally {
+      setState(() {
+        _loading = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Sign Up')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: SingleChildScrollView(
+          child: Column(
+            children: [
+              TextField(
+                controller: _emailController,
+                decoration: const InputDecoration(labelText: 'Email'),
+              ),
+              const SizedBox(height: 12),
+              TextField(
+                controller: _passwordController,
+                decoration: const InputDecoration(labelText: 'Password'),
+                obscureText: true,
+              ),
+              const SizedBox(height: 12),
+              TextField(
+                controller: _openaiKeyController,
+                decoration: const InputDecoration(labelText: 'OpenAI API Key'),
+              ),
+              const SizedBox(height: 12),
+              TextField(
+                controller: _finnhubKeyController,
+                decoration: const InputDecoration(labelText: 'Finnhub API Key'),
+              ),
+              const SizedBox(height: 16),
+              if (_error != null)
+                Text(_error!, style: const TextStyle(color: Colors.red)),
+              if (_success != null)
+                Text(_success!, style: const TextStyle(color: Colors.green)),
+              const SizedBox(height: 12),
+              _loading
+                  ? const CircularProgressIndicator()
+                  : SizedBox(
+                      width: double.infinity,
+                      child: ElevatedButton(
+                        onPressed: _register,
+                        child: const Text('Sign Up'),
+                      ),
+                    ),
+              TextButton(
+                onPressed: () {
+                  Navigator.of(context).pop();
+                },
+                child: const Text('Already have an account? Login'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -1,0 +1,23 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+class AuthService {
+  static const _tokenKey = 'auth_token';
+  static String? token;
+
+  static Future<void> loadToken() async {
+    final prefs = await SharedPreferences.getInstance();
+    token = prefs.getString(_tokenKey);
+  }
+
+  static Future<void> saveToken(String value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_tokenKey, value);
+    token = value;
+  }
+
+  static Future<void> clearToken() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_tokenKey);
+    token = null;
+  }
+}

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -35,6 +35,7 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
   http: ^1.2.1
+  shared_preferences: ^2.2.2
 
 dev_dependencies:
   # The "flutter_lints" package below contains a set of recommended lints to


### PR DESCRIPTION
## Summary
- add `LoginScreen` and `RegisterScreen` for basic authentication UI
- create `AuthService` to persist JWT tokens
- wire up authentication flow in `main.dart` with routes
- create placeholder `HomeScreen`
- add `shared_preferences` dependency for secure token storage

## Testing
- `flutter pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68754ad7f4a4832087b21b1cd728f3bb