### PR TITLE
Add analysis history UI

### DIFF
--- a/mobile/lib/analysis_detail_screen.dart
+++ b/mobile/lib/analysis_detail_screen.dart
@@ -1,0 +1,97 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+
+import 'services/auth_service.dart';
+
+const String backendUrl = 'http://localhost:8000';
+
+class AnalysisDetailScreen extends StatefulWidget {
+  final int recordId;
+
+  const AnalysisDetailScreen({super.key, required this.recordId});
+
+  @override
+  State<AnalysisDetailScreen> createState() => _AnalysisDetailScreenState();
+}
+
+class _AnalysisDetailScreenState extends State<AnalysisDetailScreen> {
+  bool _loading = false;
+  String? _error;
+  String? _decision;
+  String? _report;
+
+  @override
+  void initState() {
+    super.initState();
+    _fetchDetail();
+  }
+
+  Future<void> _fetchDetail() async {
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+
+    try {
+      final response = await http.get(
+        Uri.parse('$backendUrl/history/${widget.recordId}'),
+        headers: {'Authorization': 'Bearer ${AuthService.token}'},
+      );
+      if (response.statusCode == 200) {
+        final data = jsonDecode(response.body) as Map<String, dynamic>;
+        setState(() {
+          _decision = data['decision']?.toString();
+          _report = jsonEncode(data['report']);
+        });
+      } else {
+        setState(() {
+          _error = 'Failed to load details';
+        });
+      }
+    } catch (e) {
+      setState(() {
+        _error = 'Error: $e';
+      });
+    } finally {
+      setState(() {
+        _loading = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Analysis Details'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: _loading
+            ? const Center(child: CircularProgressIndicator())
+            : _error != null
+                ? Center(child: Text(_error!))
+                : _decision == null
+                    ? const SizedBox.shrink()
+                    : Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            'Decision: $_decision',
+                            style: const TextStyle(
+                                fontSize: 18, fontWeight: FontWeight.bold),
+                          ),
+                          const SizedBox(height: 8),
+                          Expanded(
+                            child: SingleChildScrollView(
+                              child: SelectableText(_report ?? ''),
+                            ),
+                          ),
+                        ],
+                      ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/analysis_screen.dart
+++ b/mobile/lib/analysis_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 
 import 'login_screen.dart';
+import 'history_screen.dart';
 import 'services/auth_service.dart';
 
 const String backendUrl = 'http://localhost:8000';
@@ -101,6 +102,17 @@ class _AnalysisScreenState extends State<AnalysisScreen> {
       appBar: AppBar(
         title: const Text('Analysis'),
         actions: [
+          IconButton(
+            onPressed: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (_) => const HistoryScreen(),
+                ),
+              );
+            },
+            icon: const Icon(Icons.history),
+            tooltip: 'History',
+          ),
           IconButton(
             onPressed: _logout,
             icon: const Icon(Icons.logout),

--- a/mobile/lib/history_screen.dart
+++ b/mobile/lib/history_screen.dart
@@ -1,0 +1,96 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+
+import 'analysis_detail_screen.dart';
+import 'services/auth_service.dart';
+
+const String backendUrl = 'http://localhost:8000';
+
+class HistoryScreen extends StatefulWidget {
+  const HistoryScreen({super.key});
+
+  @override
+  State<HistoryScreen> createState() => _HistoryScreenState();
+}
+
+class _HistoryScreenState extends State<HistoryScreen> {
+  bool _loading = false;
+  String? _error;
+  List<dynamic> _records = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _fetchHistory();
+  }
+
+  Future<void> _fetchHistory() async {
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+
+    try {
+      final response = await http.get(
+        Uri.parse('$backendUrl/history'),
+        headers: {'Authorization': 'Bearer ${AuthService.token}'},
+      );
+      if (response.statusCode == 200) {
+        final data = jsonDecode(response.body) as List<dynamic>;
+        setState(() {
+          _records = data;
+        });
+      } else {
+        setState(() {
+          _error = 'Failed to load history';
+        });
+      }
+    } catch (e) {
+      setState(() {
+        _error = 'Error: $e';
+      });
+    } finally {
+      setState(() {
+        _loading = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('History'),
+      ),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : _error != null
+              ? Center(child: Text(_error!))
+              : _records.isEmpty
+                  ? const Center(child: Text('No past analyses yet'))
+                  : ListView.builder(
+                      itemCount: _records.length,
+                      itemBuilder: (context, index) {
+                        final item = _records[index] as Map<String, dynamic>;
+                        final title = '${item['ticker']} on ${item['date']}';
+                        final subtitle = (item['decision'] ?? '').toString();
+                        return ListTile(
+                          title: Text(title),
+                          subtitle: Text(subtitle),
+                          onTap: () {
+                            Navigator.of(context).push(
+                              MaterialPageRoute(
+                                builder: (_) => AnalysisDetailScreen(
+                                  recordId: item['id'] as int,
+                                ),
+                              ),
+                            );
+                          },
+                        );
+                      },
+                    ),
+    );
+  }
+}

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import 'analysis_screen.dart';
+import 'history_screen.dart';
 import 'login_screen.dart';
 import 'register_screen.dart';
 import 'services/auth_service.dart';
@@ -27,6 +28,7 @@ class LetAgentsDYORApp extends StatelessWidget {
         '/login': (_) => const LoginScreen(),
         '/register': (_) => const RegisterScreen(),
         '/analysis': (_) => const AnalysisScreen(),
+        '/history': (_) => const HistoryScreen(),
       },
     );
   }


### PR DESCRIPTION
## Summary
- add history list fetching `/history`
- allow opening details via `/history/{id}`
- expose `HistoryScreen` in routes and from analysis screen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68754ea935388320b55094adcf607264