### PR TITLE
Render insights only when data available

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -84,6 +84,19 @@ class UserLogin(BaseModel):
     password: str
 
 
+def compute_data_availability(state: dict) -> dict:
+    """Return flags indicating which sections contain useful data."""
+    return {
+        "macro_news": bool(state.get("news_report")),
+        "analyst_breakdown": bool(
+            state.get("investment_debate_state", {}).get("history")
+        ),
+        "risk_assessment": bool(state.get("risk_debate_state", {}).get("history")),
+        "bullish_momentum": bool(state.get("market_report")),
+        "inflow_up": bool(state.get("fundamentals_report")),
+    }
+
+
 @app.get("/")
 def read_root():
     """Health check route."""
@@ -158,6 +171,7 @@ full_report=json.dumps(final_state),
             "date": request.date,
             "decision": decision,
             "report": final_state,
+            "availability": compute_data_availability(final_state),
         }
     except Exception as exc:
         raise HTTPException(status_code=500, detail=str(exc))
@@ -232,6 +246,7 @@ def analyze_stream(
                         "date": request.date,
                         "decision": decision,
                         "report": final_state,
+                        "availability": compute_data_availability(final_state),
                     }
                 ),
             )

--- a/mobile/lib/analysis_screen.dart
+++ b/mobile/lib/analysis_screen.dart
@@ -8,6 +8,7 @@ import 'login_screen.dart';
 import 'history_screen.dart';
 import 'services/auth_service.dart';
 import 'ticker_utils.dart';
+import 'data_availability.dart';
 
 const String backendUrl = 'http://localhost:8000';
 
@@ -27,6 +28,9 @@ class _AnalysisScreenState extends State<AnalysisScreen> {
   String? _error;
   String? _decision;
   String? _report;
+  Map<String, dynamic>? _parsedReport;
+  DataAvailability _availability = const DataAvailability.empty();
+  Future<void>? _analysisFuture;
   final List<String> _messages = [];
 
   Future<void> _pickDate() async {
@@ -43,6 +47,11 @@ class _AnalysisScreenState extends State<AnalysisScreen> {
   }
 
   Future<void> _analyze() async {
+    _analysisFuture = _runAnalysis();
+    await _analysisFuture;
+  }
+
+  Future<void> _runAnalysis() async {
     final ticker = _tickerController.text.trim().toUpperCase();
     final date = _dateController.text.trim();
 
@@ -69,6 +78,8 @@ class _AnalysisScreenState extends State<AnalysisScreen> {
       _error = null;
       _decision = null;
       _report = null;
+      _parsedReport = null;
+      _availability = const DataAvailability.empty();
     });
 
     try {
@@ -115,7 +126,12 @@ class _AnalysisScreenState extends State<AnalysisScreen> {
             } else if (event == 'complete') {
               _progress = 1.0;
               _decision = data['decision']?.toString();
+              _parsedReport = data['report'] as Map<String, dynamic>?;
               _report = jsonEncode(data['report']);
+              _availability = data.containsKey('availability')
+                  ? DataAvailability.fromJson(
+                      data['availability'] as Map<String, dynamic>)
+                  : const DataAvailability.empty();
               _loading = false;
             } else if (event == 'error') {
               _error = data['detail']?.toString();
@@ -260,87 +276,87 @@ class _AnalysisScreenState extends State<AnalysisScreen> {
   }
 
   Widget _buildHighlights() {
-    return Wrap(
-      spacing: 8,
-      children: const [
-        Chip(avatar: Icon(Icons.trending_up), label: Text('Bullish Momentum')),
-        Chip(avatar: Icon(Icons.attach_money), label: Text('Inflow Up')),
-        Chip(avatar: Icon(Icons.flag), label: Text('Low Risk')),
-      ],
+    return FutureBuilder<void>(
+      future: _analysisFuture,
+      builder: (context, snapshot) {
+        if (!_availability.anyChip || snapshot.connectionState != ConnectionState.done) {
+          return const SizedBox.shrink();
+        }
+        final chips = <Widget>[];
+        if (_availability.bullishMomentum) {
+          chips.add(const Chip(
+              avatar: Icon(Icons.trending_up), label: Text('Bullish Momentum')));
+        }
+        if (_availability.inflowUp) {
+          chips.add(const Chip(
+              avatar: Icon(Icons.attach_money), label: Text('Inflow Up')));
+        }
+        if (_availability.riskAssessment) {
+          chips.add(const Chip(
+              avatar: Icon(Icons.flag), label: Text('Low Risk')));
+        }
+        return Wrap(spacing: 8, children: chips);
+      },
     );
   }
 
   Widget _buildInsightSections() {
-    return ExpansionPanelList.radio(
-      children: [
-        ExpansionPanelRadio(
-          value: 'news',
-          headerBuilder: (context, isExpanded) => const ListTile(
-            title: Text('Macro & Market News'),
-          ),
-          body: Column(
-            children: const [
-              ListTile(
-                title: Text('Headline 1'),
-                subtitle: Text('Economic news summary'),
+    return FutureBuilder<void>(
+      future: _analysisFuture,
+      builder: (context, snapshot) {
+        if (!_availability.anyPanel || snapshot.connectionState != ConnectionState.done) {
+          return const SizedBox.shrink();
+        }
+        final panels = <ExpansionPanelRadio>[];
+        if (_availability.macroNews && _parsedReport?['news_report'] != null) {
+          panels.add(
+            ExpansionPanelRadio(
+              value: 'news',
+              headerBuilder: (context, isExpanded) => const ListTile(
+                title: Text('Macro & Market News'),
               ),
-              ListTile(
-                title: Text('Headline 2'),
-                subtitle: Text('More news'),
+              body: Padding(
+                padding: const EdgeInsets.all(8),
+                child: SelectableText(_parsedReport!['news_report'] as String),
               ),
-              ListTile(
-                title: Text('Headline 3'),
-                subtitle: Text('Third news item'),
+            ),
+          );
+        }
+        if (_availability.analystBreakdown &&
+            _parsedReport?['investment_debate_state'] != null) {
+          panels.add(
+            ExpansionPanelRadio(
+              value: 'analysts',
+              headerBuilder: (context, isExpanded) => const ListTile(
+                title: Text('Analyst Team Breakdown'),
               ),
-            ],
-          ),
-        ),
-        ExpansionPanelRadio(
-          value: 'analysts',
-          headerBuilder: (context, isExpanded) => const ListTile(
-            title: Text('Analyst Team Breakdown'),
-          ),
-          body: Column(
-            children: const [
-              ListTile(
-                leading: CircleAvatar(child: Text('RA')),
-                title: Text('Risky Analyst'),
-                subtitle: Text('Sell -30%'),
+              body: Padding(
+                padding: const EdgeInsets.all(8),
+                child: SelectableText(
+                    _parsedReport!['investment_debate_state']['history'] as String),
               ),
-              ListTile(
-                leading: CircleAvatar(child: Text('BA')),
-                title: Text('Bull Analyst'),
-                subtitle: Text('Buy +20%'),
+            ),
+          );
+        }
+        if (_availability.riskAssessment &&
+            _parsedReport?['risk_debate_state'] != null) {
+          panels.add(
+            ExpansionPanelRadio(
+              value: 'risk',
+              headerBuilder: (context, isExpanded) => const ListTile(
+                title: Text('Risk Assessment'),
               ),
-            ],
-          ),
-        ),
-        ExpansionPanelRadio(
-          value: 'risk',
-          headerBuilder: (context, isExpanded) => const ListTile(
-            title: Text('Risk Assessment'),
-          ),
-          body: Column(
-            children: const [
-              ListTile(
-                leading: Icon(Icons.bar_chart),
-                title: Text('Technical Risk'),
-                subtitle: Text('Overbought'),
+              body: Padding(
+                padding: const EdgeInsets.all(8),
+                child: SelectableText(
+                    _parsedReport!['risk_debate_state']['history'] as String),
               ),
-              ListTile(
-                leading: Icon(Icons.language),
-                title: Text('Geopolitical Risk'),
-                subtitle: Text('Low'),
-              ),
-              ListTile(
-                leading: Icon(Icons.warning),
-                title: Text('Earnings Triggers'),
-                subtitle: Text('Next week'),
-              ),
-            ],
-          ),
-        ),
-      ],
+            ),
+          );
+        }
+        if (panels.isEmpty) return const SizedBox.shrink();
+        return ExpansionPanelList.radio(children: panels);
+      },
     );
   }
 

--- a/mobile/lib/data_availability.dart
+++ b/mobile/lib/data_availability.dart
@@ -1,0 +1,37 @@
+class DataAvailability {
+  final bool macroNews;
+  final bool analystBreakdown;
+  final bool riskAssessment;
+  final bool bullishMomentum;
+  final bool inflowUp;
+
+  const DataAvailability({
+    required this.macroNews,
+    required this.analystBreakdown,
+    required this.riskAssessment,
+    required this.bullishMomentum,
+    required this.inflowUp,
+  });
+
+  factory DataAvailability.fromJson(Map<String, dynamic> json) {
+    return DataAvailability(
+      macroNews: json['macro_news'] ?? false,
+      analystBreakdown: json['analyst_breakdown'] ?? false,
+      riskAssessment: json['risk_assessment'] ?? false,
+      bullishMomentum: json['bullish_momentum'] ?? false,
+      inflowUp: json['inflow_up'] ?? false,
+    );
+  }
+
+  const DataAvailability.empty()
+      : macroNews = false,
+        analystBreakdown = false,
+        riskAssessment = false,
+        bullishMomentum = false,
+        inflowUp = false;
+
+  bool get anyChip => bullishMomentum || inflowUp || riskAssessment;
+
+  bool get anyPanel => macroNews || analystBreakdown || riskAssessment;
+}
+


### PR DESCRIPTION
## Summary
- add `compute_data_availability` in backend
- return data availability with `/analyze` and `/analyze/stream`
- add `DataAvailability` model to mobile app
- show highlight chips and insight panels only when valid data exists

## Testing
- `pytest -q`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68781b84750483208b9cd8ab6767cff0