### PR TITLE
Fix NDK version in Android build

### DIFF
--- a/mobile/android/app/build.gradle.kts
+++ b/mobile/android/app/build.gradle.kts
@@ -8,7 +8,8 @@ plugins {
 android {
     namespace = "com.example.letagentsdyor_app"
     compileSdk = flutter.compileSdkVersion
-    ndkVersion = flutter.ndkVersion
+    // Use the NDK version required by the Flutter plugin to avoid build issues
+    ndkVersion = "27.0.12077973"
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11


### PR DESCRIPTION
## Summary
- set Flutter NDK version in `mobile/android/app/build.gradle.kts`

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d06f7d56c832096e09175b35fc8ea