### PR TITLE
Fix mobile backend URL configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,9 @@ LetAgents_DYOR orchestrates multiple AI agents to help you analyze equities with
    ```bash
    cd ../mobile
    flutter pub get
-   flutter run
+   flutter run --dart-define=BACKEND_URL=http://<your-ip>:8000
    ```
+   Replace `<your-ip>` with the machine running the backend when testing on a real device.
 
 ## 🧑‍💻 Developer Guide
 

--- a/mobile/lib/analysis_detail_screen.dart
+++ b/mobile/lib/analysis_detail_screen.dart
@@ -4,8 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 
 import 'services/auth_service.dart';
-
-const String backendUrl = 'http://localhost:8000';
+import 'config.dart';
 
 class AnalysisDetailScreen extends StatefulWidget {
   final int recordId;

--- a/mobile/lib/analysis_screen.dart
+++ b/mobile/lib/analysis_screen.dart
@@ -10,8 +10,7 @@ import 'history_screen.dart';
 import 'services/auth_service.dart';
 import 'ticker_utils.dart';
 import 'data_availability.dart';
-
-const String backendUrl = 'http://localhost:8000';
+import 'config.dart';
 
 class AnalysisScreen extends StatefulWidget {
   const AnalysisScreen({super.key});

--- a/mobile/lib/config.dart
+++ b/mobile/lib/config.dart
@@ -1,0 +1,4 @@
+const String backendUrl = String.fromEnvironment(
+  'BACKEND_URL',
+  defaultValue: 'http://localhost:8000',
+);

--- a/mobile/lib/history_screen.dart
+++ b/mobile/lib/history_screen.dart
@@ -5,8 +5,7 @@ import 'package:http/http.dart' as http;
 
 import 'analysis_detail_screen.dart';
 import 'services/auth_service.dart';
-
-const String backendUrl = 'http://localhost:8000';
+import 'config.dart';
 
 class HistoryScreen extends StatefulWidget {
   const HistoryScreen({super.key});

--- a/mobile/lib/login_screen.dart
+++ b/mobile/lib/login_screen.dart
@@ -6,8 +6,7 @@ import 'package:http/http.dart' as http;
 import 'analysis_screen.dart';
 import 'register_screen.dart';
 import 'services/auth_service.dart';
-
-const String backendUrl = 'http://localhost:8000';
+import 'config.dart';
 
 class LoginScreen extends StatefulWidget {
   const LoginScreen({super.key});

--- a/mobile/lib/register_screen.dart
+++ b/mobile/lib/register_screen.dart
@@ -4,8 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 
 import 'login_screen.dart';
-
-const String backendUrl = 'http://localhost:8000';
+import 'config.dart';
 
 class RegisterScreen extends StatefulWidget {
   const RegisterScreen({super.key});


### PR DESCRIPTION
## Summary
- centralize backend URL in `config.dart`
- update Flutter screens to import new config
- document how to set `BACKEND_URL` when running the app

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d0724fddc8320bc9c3013f34982a8