### PR TITLE
Add profile API keys management

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -14,11 +14,12 @@ class AnalysisRecord(Base):
     decision = Column(Text, nullable=False)
     full_report = Column(Text, nullable=False)
 
+
 class User(Base):
     __tablename__ = "users"
 
     id = Column(Integer, primary_key=True, index=True)
     email = Column(String, unique=True, index=True, nullable=False)
     password_hash = Column(String, nullable=False)
-    openai_api_key = Column(String, nullable=False)
-    finnhub_api_key = Column(String, nullable=False)
+    openai_api_key = Column(String, nullable=True)
+    finnhub_api_key = Column(String, nullable=True)

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -5,6 +5,7 @@ import 'history_screen.dart';
 import 'login_screen.dart';
 import 'register_screen.dart';
 import 'services/auth_service.dart';
+import 'profile_screen.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -32,6 +33,7 @@ class LetAgentsDYORApp extends StatelessWidget {
         '/register': (_) => const RegisterScreen(),
         '/analysis': (_) => const AnalysisScreen(),
         '/history': (_) => const HistoryScreen(),
+        '/profile': (_) => const ProfileScreen(),
       },
     );
   }

--- a/mobile/lib/profile_screen.dart
+++ b/mobile/lib/profile_screen.dart
@@ -1,0 +1,112 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+
+import 'services/auth_service.dart';
+import 'config.dart';
+
+class ProfileScreen extends StatefulWidget {
+  const ProfileScreen({super.key});
+
+  @override
+  State<ProfileScreen> createState() => _ProfileScreenState();
+}
+
+class _ProfileScreenState extends State<ProfileScreen> {
+  final _openaiController = TextEditingController();
+  final _finnhubController = TextEditingController();
+  bool _loading = false;
+  String? _error;
+  String? _success;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadProfile();
+  }
+
+  Future<void> _loadProfile() async {
+    try {
+      final resp = await http.get(
+        Uri.parse('$backendUrl/me'),
+        headers: {'Authorization': 'Bearer ${AuthService.token}'},
+      );
+      if (resp.statusCode == 200) {
+        final data = jsonDecode(resp.body) as Map<String, dynamic>;
+        setState(() {
+          _openaiController.text = data['openai_api_key'] ?? '';
+          _finnhubController.text = data['finnhub_api_key'] ?? '';
+        });
+      }
+    } catch (_) {}
+  }
+
+  Future<void> _save() async {
+    setState(() {
+      _loading = true;
+      _error = null;
+      _success = null;
+    });
+    try {
+      final resp = await http.put(
+        Uri.parse('$backendUrl/keys'),
+        headers: {
+          'Authorization': 'Bearer ${AuthService.token}',
+          'Content-Type': 'application/json'
+        },
+        body: jsonEncode({
+          'openai_api_key': _openaiController.text,
+          'finnhub_api_key': _finnhubController.text,
+        }),
+      );
+      if (resp.statusCode == 200) {
+        setState(() => _success = 'Saved');
+      } else {
+        setState(() => _error = 'Failed to save');
+      }
+    } catch (e) {
+      setState(() => _error = 'Error: $e');
+    } finally {
+      setState(() => _loading = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Profile')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            TextField(
+              controller: _openaiController,
+              decoration: const InputDecoration(labelText: 'OpenAI API Key'),
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _finnhubController,
+              decoration: const InputDecoration(labelText: 'Finnhub API Key'),
+            ),
+            const SizedBox(height: 16),
+            if (_error != null)
+              Text(_error!, style: const TextStyle(color: Colors.red)),
+            if (_success != null)
+              Text(_success!, style: const TextStyle(color: Colors.green)),
+            const SizedBox(height: 12),
+            _loading
+                ? const CircularProgressIndicator()
+                : SizedBox(
+                    width: double.infinity,
+                    child: ElevatedButton(
+                      onPressed: _save,
+                      child: const Text('Save'),
+                    ),
+                  ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/register_screen.dart
+++ b/mobile/lib/register_screen.dart
@@ -16,8 +16,6 @@ class RegisterScreen extends StatefulWidget {
 class _RegisterScreenState extends State<RegisterScreen> {
   final _emailController = TextEditingController();
   final _passwordController = TextEditingController();
-  final _openaiKeyController = TextEditingController();
-  final _finnhubKeyController = TextEditingController();
   bool _loading = false;
   String? _error;
   String? _success;
@@ -36,8 +34,6 @@ class _RegisterScreenState extends State<RegisterScreen> {
         body: jsonEncode({
           'email': _emailController.text,
           'password': _passwordController.text,
-          'openai_api_key': _openaiKeyController.text,
-          'finnhub_api_key': _finnhubKeyController.text,
         }),
       );
       if (response.statusCode == 200) {
@@ -78,16 +74,6 @@ class _RegisterScreenState extends State<RegisterScreen> {
                 controller: _passwordController,
                 decoration: const InputDecoration(labelText: 'Password'),
                 obscureText: true,
-              ),
-              const SizedBox(height: 12),
-              TextField(
-                controller: _openaiKeyController,
-                decoration: const InputDecoration(labelText: 'OpenAI API Key'),
-              ),
-              const SizedBox(height: 12),
-              TextField(
-                controller: _finnhubKeyController,
-                decoration: const InputDecoration(labelText: 'Finnhub API Key'),
               ),
               const SizedBox(height: 16),
               if (_error != null)


### PR DESCRIPTION
## Summary
- allow users to register without API keys
- expose `/me` and `/keys` endpoints for managing keys
- require keys before analysing
- add new Flutter `ProfileScreen`
- use a drawer in `AnalysisScreen` with Profile/History/Logout
- prompt users to set keys if missing

## Testing
- `python -m py_compile backend/main.py backend/models.py`
- ❌ `dart format mobile/lib` *(dart unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_687d1d1c8be08320ae91a18c0ddc3e43