### PR TITLE
Add About screen for TradingAgents info

### DIFF
--- a/mobile/lib/about_screen.dart
+++ b/mobile/lib/about_screen.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+
+class AboutScreen extends StatelessWidget {
+  const AboutScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('About')),
+      body: const SingleChildScrollView(
+        padding: EdgeInsets.all(16),
+        child: Text(_aboutText),
+      ),
+    );
+  }
+}
+
+const String _aboutText = '''
+TradingAgents is a multi-agent trading framework that mirrors the dynamics of real-world trading firms. By deploying specialized LLM-powered agents—ranging from fundamentals analysts and sentiment experts to researchers, trader and risk management roles—the platform collaboratively evaluates market conditions and informs trading decisions.
+
+The LetAgents_DYOR app orchestrates these agents behind the scenes. When you request an analysis for a particular stock and date, each agent gathers data or insights and debates with other agents to form the best strategy. A trader agent then composes the results into a report, which the risk management team reviews before finalizing a simulated trade decision.
+
+The generated reports depend on the language models, data quality and other factors, so results may vary and are provided for research curiosity only—not as financial advice. For more details on the underlying framework visit https://github.com/TauricResearch/TradingAgents.
+''';

--- a/mobile/lib/analysis_screen.dart
+++ b/mobile/lib/analysis_screen.dart
@@ -8,6 +8,7 @@ import 'package:flutter_markdown/flutter_markdown.dart';
 import 'login_screen.dart';
 import 'history_screen.dart';
 import 'profile_screen.dart';
+import 'about_screen.dart';
 import 'services/auth_service.dart';
 import 'ticker_utils.dart';
 import 'data_availability.dart';
@@ -343,6 +344,15 @@ class _AnalysisScreenState extends State<AnalysisScreen> {
               onTap: () {
                 Navigator.of(context).push(
                   MaterialPageRoute(builder: (_) => const HistoryScreen()),
+                );
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.info_outline),
+              title: const Text('About'),
+              onTap: () {
+                Navigator.of(context).push(
+                  MaterialPageRoute(builder: (_) => const AboutScreen()),
                 );
               },
             ),

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -6,6 +6,7 @@ import 'login_screen.dart';
 import 'register_screen.dart';
 import 'services/auth_service.dart';
 import 'profile_screen.dart';
+import 'about_screen.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -34,6 +35,7 @@ class LetAgentsDYORApp extends StatelessWidget {
         '/analysis': (_) => const AnalysisScreen(),
         '/history': (_) => const HistoryScreen(),
         '/profile': (_) => const ProfileScreen(),
+        '/about': (_) => const AboutScreen(),
       },
     );
   }


### PR DESCRIPTION
## Summary
- add a new AboutScreen explaining how the multi-agent system works
- link to About from the drawer and app routes

## Testing
- `flutter test -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e9cb0fff88320b31726bd72559ef5