### PR TITLE
Add live analysis metrics

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -13,6 +13,9 @@ class AnalysisRecord(Base):
     date = Column(String, nullable=False)
     decision = Column(Text, nullable=False)
     full_report = Column(Text, nullable=False)
+    tool_calls = Column(Integer, default=0)
+    llm_calls = Column(Integer, default=0)
+    reports_generated = Column(Integer, default=0)
 
 
 class User(Base):

--- a/mobile/lib/history_screen.dart
+++ b/mobile/lib/history_screen.dart
@@ -75,9 +75,11 @@ class _HistoryScreenState extends State<HistoryScreen> {
                         final item = _records[index] as Map<String, dynamic>;
                         final title = '${item['ticker']} on ${item['date']}';
                         final subtitle = (item['decision'] ?? '').toString();
+                        final m = item['metrics'] as Map<String, dynamic>?;
+                        final metricsText = m == null ? '' : ' | Tools: ' + m['tool_calls'].toString() + '  LLM: ' + m['llm_calls'].toString() + '  Reports: ' + m['reports'].toString();
                         return ListTile(
                           title: Text(title),
-                          subtitle: Text(subtitle),
+                          subtitle: Text(subtitle + metricsText),
                           onTap: () {
                             Navigator.of(context).push(
                               MaterialPageRoute(


### PR DESCRIPTION
## Summary
- store tool call, LLM call and report counts in `AnalysisRecord`
- compute metrics during analysis and stream live updates
- expose metrics in history API
- display metrics in Flutter analysis and history views

## Testing
- `python -m py_compile backend/main.py backend/models.py`

------
https://chatgpt.com/codex/tasks/task_e_687eadbdd39c8320b9e726998653100c