### PR TITLE
Prevent screen sleep during mobile analysis

### DIFF
--- a/mobile/lib/analysis_screen.dart
+++ b/mobile/lib/analysis_screen.dart
@@ -4,6 +4,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'package:flutter_markdown/flutter_markdown.dart';
+import 'package:wakelock_plus/wakelock_plus.dart';
 
 import 'login_screen.dart';
 import 'history_screen.dart';
@@ -180,6 +181,7 @@ class _AnalysisScreenState extends State<AnalysisScreen> {
       _loading = false;
     });
     _activeClient?.close();
+    WakelockPlus.disable();
   }
 
   Future<void> _runAnalysis() async {
@@ -208,6 +210,8 @@ class _AnalysisScreenState extends State<AnalysisScreen> {
     }
 
     _tickerController.text = ticker;
+
+    await WakelockPlus.enable();
 
   setState(() {
       _loading = true;
@@ -312,6 +316,7 @@ class _AnalysisScreenState extends State<AnalysisScreen> {
         _error = 'Error: $e';
       });
     } finally {
+      WakelockPlus.disable();
       client.close();
       _activeClient = null;
       if (mounted && _loading) {

--- a/mobile/lib/analysis_screen.dart
+++ b/mobile/lib/analysis_screen.dart
@@ -181,7 +181,6 @@ class _AnalysisScreenState extends State<AnalysisScreen> {
       _loading = false;
     });
     _activeClient?.close();
-    WakelockPlus.disable();
   }
 
   Future<void> _runAnalysis() async {
@@ -211,8 +210,6 @@ class _AnalysisScreenState extends State<AnalysisScreen> {
 
     _tickerController.text = ticker;
 
-    await WakelockPlus.enable();
-
   setState(() {
       _loading = true;
       _progress = 0;
@@ -231,6 +228,7 @@ class _AnalysisScreenState extends State<AnalysisScreen> {
     final client = http.Client();
     _activeClient = client;
     try {
+      await WakelockPlus.enable();
       final request = http.Request('POST', Uri.parse('$backendUrl/analyze/stream'))
         ..headers.addAll({
           'Content-Type': 'application/json',

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -37,6 +37,7 @@ dependencies:
   http: ^1.2.1
   shared_preferences: ^2.2.2
   flutter_markdown: ^0.6.17
+  wakelock_plus: ^1.3.2
 
 dev_dependencies:
   # The "flutter_lints" package below contains a set of recommended lints to


### PR DESCRIPTION
## Summary
- keep device awake while analysis is running using `wakelock_plus`
- add `wakelock_plus` to mobile dependencies

## Testing
- `dart pub get` *(fails: Flutter SDK is missing)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e9a07a978832080e449beea6c0612