### PR TITLE
Expand streaming box height

### DIFF
--- a/mobile/lib/analysis_screen.dart
+++ b/mobile/lib/analysis_screen.dart
@@ -715,7 +715,9 @@ class _AnalysisScreenState extends State<AnalysisScreen> {
           ),
           const SizedBox(height: 8),
           ConstrainedBox(
-            constraints: const BoxConstraints(maxHeight: 200),
+            constraints: BoxConstraints(
+              maxHeight: MediaQuery.of(context).size.height * 0.5,
+            ),
             child: Scrollbar(
               thumbVisibility: true,
               child: SingleChildScrollView(


### PR DESCRIPTION
## Summary
- expand the streaming box to use half of the screen height

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688137430ca08320ab59740cb4111022