### PR TITLE
Add backend Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY backend /app/backend
+RUN pip install --no-cache-dir -r backend/requirements.txt
+EXPOSE 8000
+ENTRYPOINT ["uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- add Dockerfile to package the backend using Python 3.10-slim

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68827b4cafe88320afb5a9efe1082c03