### PR TITLE
Add Oracle wallet path env example

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -51,6 +51,8 @@ docker run -d -p 80:8000 letagents-backend
    ```bash
    export OPENAI_API_KEY=your-openai-key
    export FINNHUB_API_KEY=your-finnhub-key
+   # required if using Oracle Autonomous DB
+   export ORACLE_WALLET_PATH=/path/to/your/wallet
    ```
 3. Start the server:
    ```bash

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -11,6 +11,9 @@ FINNHUB_API_KEY=
 # Defaults to SQLite when not set: sqlite:///./users.db
 DATABASE_URL=
 
+# Path to the Oracle wallet directory for Autonomous DB connections
+ORACLE_WALLET_PATH=
+
 # Secret key for signing JWT tokens
 # Defaults to "change-me" when not set
 SECRET_KEY=


### PR DESCRIPTION
## Summary
- add `ORACLE_WALLET_PATH` entry to backend `.env.example`
- document the variable in deployment guide

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68850a6ca9d8832085f3c71d572cb7f0