### PR TITLE
Use env var for data dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,9 @@ For details on how the agents work together, see [docs/ARCHITECTURE.md](docs/ARC
    pip install -r requirements.txt
    # configure environment
    cp .env.example .env  # or export variables directly
-   export OPENAI_API_KEY=your-key
-   export FINNHUB_API_KEY=your-finnhub-key
+    export OPENAI_API_KEY=your-key
+    export FINNHUB_API_KEY=your-finnhub-key
+    export TRADINGAGENTS_DATA_DIR=/path/to/your/data
    ```
 3. Build and run with Docker
    ```bash
@@ -71,7 +72,7 @@ LetAgents_DYOR/
 - Contributions are welcome! Open issues or submit pull requests.
 - The CLI can still be executed via `python -m cli.main` or you can call `POST /analyze` from the API.
 - Retrieve past analyses with `GET /history` and view details with `GET /history/{id}`.
-- Environment variables can be set in `backend/.env` or exported before running the server.
+ - Environment variables can be set in `backend/.env` or exported before running the server. `TRADINGAGENTS_DATA_DIR` controls where the backend reads its data files.
 - Start the FastAPI server locally with:
   ```bash
   pip install -r backend/requirements.txt

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -3,7 +3,7 @@ import os
 DEFAULT_CONFIG = {
     "project_dir": os.path.abspath(os.path.join(os.path.dirname(__file__), ".")),
     "results_dir": os.getenv("TRADINGAGENTS_RESULTS_DIR", "./results"),
-    "data_dir": "/Users/yluo/Documents/Code/ScAI/FR1-data",
+    "data_dir": os.getenv("TRADINGAGENTS_DATA_DIR", "./data"),
     "data_cache_dir": os.path.join(
         os.path.abspath(os.path.join(os.path.dirname(__file__), ".")),
         "dataflows/data_cache",


### PR DESCRIPTION
## Summary
- configure default config to read `TRADINGAGENTS_DATA_DIR`
- document the variable in README

## Testing
- `python -m py_compile tradingagents/default_config.py`

------
https://chatgpt.com/codex/tasks/task_e_68850ab7e43883208c7abd5f25a3337d