### PR TITLE
Initialize analytics on FastAPI startup

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -4,6 +4,8 @@ from langchain_core.messages import BaseMessage
 from typing import List, Optional
 from datetime import datetime
 
+import backend.analytics
+
 import jwt
 from fastapi import FastAPI, HTTPException, Depends, status
 from fastapi.security import OAuth2PasswordBearer


### PR DESCRIPTION
## Summary
- import `backend.analytics` when `backend.main` loads

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68851c5baadc8320a3c968d7413e1260