### PR TITLE
Add PostHog error tracking

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -5,7 +5,8 @@ from typing import List, Optional
 from datetime import datetime
 
 import jwt
-from fastapi import FastAPI, HTTPException, Depends, status
+from fastapi import FastAPI, HTTPException, Depends, status, Request
+from fastapi.responses import JSONResponse
 from fastapi.security import OAuth2PasswordBearer
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
@@ -22,8 +23,36 @@ from .analysis_result_service import (
 )
 from passlib.context import CryptContext
 from sse_starlette.sse import EventSourceResponse, ServerSentEvent
+import posthog
 
 app = FastAPI()
+
+# Configure PostHog if a key is provided
+POSTHOG_API_KEY = os.getenv("POSTHOG_API_KEY")
+POSTHOG_HOST = os.getenv("POSTHOG_HOST", "https://app.posthog.com")
+if POSTHOG_API_KEY:
+    posthog.project_api_key = POSTHOG_API_KEY
+    posthog.host = POSTHOG_HOST
+
+# Global exception handler to report unexpected errors
+@app.exception_handler(Exception)
+async def capture_exceptions(request: Request, exc: Exception):
+    if POSTHOG_API_KEY:
+        try:
+            posthog.capture(
+                distinct_id="backend",
+                event="error",
+                properties={
+                    "path": request.url.path,
+                    "error": str(exc),
+                },
+            )
+        except Exception:
+            pass
+    return JSONResponse(
+        status_code=500,
+        content={"detail": "Internal Server Error"},
+    )
 
 # Allow all origins for development; restrict in production
 app.add_middleware(

--- a/backend/main.py
+++ b/backend/main.py
@@ -39,12 +39,14 @@ if POSTHOG_API_KEY:
 async def capture_exceptions(request: Request, exc: Exception):
     if POSTHOG_API_KEY:
         try:
+            import traceback
             posthog.capture(
                 distinct_id="backend",
                 event="error",
                 properties={
                     "path": request.url.path,
                     "error": str(exc),
+                    "traceback": traceback.format_exc(),
                 },
             )
         except Exception:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,3 +4,4 @@ sqlalchemy
 passlib[bcrypt]
 PyJWT
 sse-starlette
+posthog


### PR DESCRIPTION
## Summary
- capture unhandled server errors and send to PostHog
- add PostHog dependency for backend

## Testing
- `python -m py_compile backend/main.py`
- `pytest -q`
- `pip install -q -r backend/requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_68851c8b767483209f5a7e062433a3aa