### PR TITLE
Add PostHog user identification

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ For details on how the agents work together, see [docs/ARCHITECTURE.md](docs/ARC
     export OPENAI_API_KEY=your-key
     export FINNHUB_API_KEY=your-finnhub-key
     export TRADINGAGENTS_DATA_DIR=/path/to/your/data
+    # Optional analytics with PostHog
+    export POSTHOG_API_KEY=phc_xxx
    ```
 3. Build and run with Docker
    ```bash

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -17,3 +17,9 @@ ORACLE_WALLET_PATH=
 # Secret key for signing JWT tokens
 # Defaults to "change-me" when not set
 SECRET_KEY=
+
+# Optional PostHog API key to enable analytics
+# If not set, analytics are disabled
+POSTHOG_API_KEY=
+# Override PostHog host if using self-hosted instance
+POSTHOG_HOST=https://app.posthog.com

--- a/backend/main.py
+++ b/backend/main.py
@@ -3,6 +3,7 @@ import json
 from langchain_core.messages import BaseMessage
 from typing import List, Optional
 from datetime import datetime
+import posthog
 
 import jwt
 from fastapi import FastAPI, HTTPException, Depends, status
@@ -36,6 +37,15 @@ app.add_middleware(
 
 # Initialize database
 Base.metadata.create_all(bind=engine)
+
+POSTHOG_API_KEY = os.getenv("POSTHOG_API_KEY")
+POSTHOG_HOST = os.getenv("POSTHOG_HOST", "https://app.posthog.com")
+if POSTHOG_API_KEY:
+    posthog.project_api_key = POSTHOG_API_KEY
+    posthog.host = POSTHOG_HOST
+    POSTHOG_ENABLED = True
+else:
+    POSTHOG_ENABLED = False
 
 def _ensure_analysis_columns():
     """Create new columns in analysis_records if they don't exist."""
@@ -215,6 +225,8 @@ def register(user: UserCreate, db: Session = Depends(get_db)):
     db.add(user_obj)
     db.commit()
     db.refresh(user_obj)
+    if POSTHOG_ENABLED:
+        posthog.identify(user_obj.id, {"email": user_obj.email})
     return {"id": user_obj.id}
 
 
@@ -226,6 +238,8 @@ def login(credentials: UserLogin, db: Session = Depends(get_db)):
             status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials"
         )
     token = create_access_token({"id": user.id, "email": user.email})
+    if POSTHOG_ENABLED:
+        posthog.identify(user.id, {"email": user.email})
     return {"token": token}
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ langchain-google-genai
 sqlalchemy
 passlib[bcrypt]
 PyJWT
+posthog


### PR DESCRIPTION
## Summary
- initialise PostHog client if `POSTHOG_API_KEY` is set
- call `posthog.identify` on sign up and login
- document PostHog env vars in README and `.env.example`
- add `posthog` dependency

## Testing
- `pytest -q`
- `python -m py_compile backend/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68851cf322388320ab12690fd2ec7993