### PR TITLE
Add auth middleware for PostHog user tracking

### DIFF
--- a/backend/auth_middleware.py
+++ b/backend/auth_middleware.py
@@ -1,0 +1,24 @@
+import os
+import jwt
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+
+SECRET_KEY = os.environ.get("SECRET_KEY", "change-me")
+ALGORITHM = "HS256"
+
+class AuthTokenMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint):
+        request.state.user = None
+        auth_header = request.headers.get("Authorization")
+        if auth_header and auth_header.lower().startswith("bearer "):
+            token = auth_header.split(" ", 1)[1]
+            try:
+                payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+                user_id = payload.get("id")
+                if user_id is not None:
+                    request.state.user = type("UserObj", (), {"id": user_id})()
+            except Exception:
+                # Ignore token errors and continue without user info
+                pass
+        response = await call_next(request)
+        return response

--- a/backend/main.py
+++ b/backend/main.py
@@ -25,6 +25,7 @@ from .analysis_result_service import (
 from passlib.context import CryptContext
 from sse_starlette.sse import EventSourceResponse, ServerSentEvent
 from .posthog_middleware import PostHogMiddleware
+from .auth_middleware import AuthTokenMiddleware
 
 app = FastAPI()
 
@@ -66,6 +67,7 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+app.add_middleware(AuthTokenMiddleware)
 app.add_middleware(PostHogMiddleware)
 
 # Initialize database


### PR DESCRIPTION
## Summary
- add middleware that decodes JWT from `Authorization` header and sets `request.state.user`
- register new middleware before `PostHogMiddleware`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68853e6bf39c8320a9c3cf9dcae2a2fc