### PR TITLE
Fix missing middleware import in backend

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -25,6 +25,7 @@ from .analysis_result_service import (
 from passlib.context import CryptContext
 from sse_starlette.sse import EventSourceResponse, ServerSentEvent
 from .posthog_middleware import PostHogMiddleware
+from .auth_middleware import AuthTokenMiddleware
 from .posthog_config import POSTHOG_ENABLED, capture_error
 
 app = FastAPI()


### PR DESCRIPTION
## Summary
- add missing `AuthTokenMiddleware` import to `backend/main.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886615230d083208b2b7e2efb833b30