### PR TITLE
Add Android release signing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,28 @@ Replace `<your-ip>` with the backend host. Use `localhost` for the iOS Simulator
         -d '{"openai_api_key":"sk-...","finnhub_api_key":"fh-..."}'
    ```
 
+## 📦 Building a Release APK
+
+To distribute the Flutter app you need to sign it and then build a release APK.
+
+1. Generate a release keystore:
+   ```bash
+   keytool -genkey -v -keystore ~/my-release-key.jks \
+     -alias my-key-alias -keyalg RSA -keysize 2048 -validity 10000
+   ```
+2. Create `mobile/android/key.properties` with your credentials:
+   ```
+   storePassword=<your-store-password>
+   keyPassword=<your-key-password>
+   keyAlias=my-key-alias
+   storeFile=../my-release-key.jks
+   ```
+3. Build the APK from the `mobile/` directory:
+   ```bash
+   flutter build apk --release
+   ```
+
+
 ## 🧑‍💻 Developer Guide
 
 ```

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ To distribute the Flutter app you need to sign it and then build a release APK.
 
 1. Generate a release keystore:
    ```bash
-   keytool -genkey -v -keystore ~/my-release-key.jks \
+   keytool -genkey -v -keystore my-release-key.jks \
      -alias my-key-alias -keyalg RSA -keysize 2048 -validity 10000
    ```
 2. Create `mobile/android/key.properties` with your credentials:

--- a/mobile/android/app/build.gradle.kts
+++ b/mobile/android/app/build.gradle.kts
@@ -1,3 +1,6 @@
+import java.util.Properties
+import java.io.FileInputStream
+
 plugins {
     id("com.android.application")
     id("kotlin-android")
@@ -31,11 +34,24 @@ android {
         versionName = flutter.versionName
     }
 
-    buildTypes {
-        release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig = signingConfigs.getByName("debug")
+    val keystorePropertiesFile = rootProject.file("key.properties")
+    if (keystorePropertiesFile.exists()) {
+        val keystoreProperties = Properties()
+        keystoreProperties.load(FileInputStream(keystorePropertiesFile))
+
+        signingConfigs {
+            create("release") {
+                storeFile = file(keystoreProperties["storeFile"] as String)
+                storePassword = keystoreProperties["storePassword"] as String
+                keyAlias = keystoreProperties["keyAlias"] as String
+                keyPassword = keystoreProperties["keyPassword"] as String
+            }
+        }
+        buildTypes {
+            getByName("release") {
+                signingConfig = signingConfigs.getByName("release")
+                isMinifyEnabled = false
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- configure signingConfig for Android release build
- document how to create a keystore and build a release APK

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888cbd2a7b483208216f2640a24c6f8