### PR TITLE
Fix Android release build

### DIFF
--- a/mobile/android/app/build.gradle.kts
+++ b/mobile/android/app/build.gradle.kts
@@ -50,7 +50,12 @@ android {
         buildTypes {
             getByName("release") {
                 signingConfig = signingConfigs.getByName("release")
-                isMinifyEnabled = false
+                isMinifyEnabled = true
+                isShrinkResources = true
+                proguardFiles(
+                    getDefaultProguardFile("proguard-android-optimize.txt"),
+                    "proguard-rules.pro"
+                )
             }
         }
     }

--- a/mobile/android/app/proguard-rules.pro
+++ b/mobile/android/app/proguard-rules.pro
@@ -1,0 +1,6 @@
+# Flutter default ProGuard rules.
+-keep class io.flutter.app.FlutterApplication { *; }
+-keep class io.flutter.plugin.common.PluginRegistry { *; }
+-keep class io.flutter.embedding.android.* { *; }
+-keep class io.flutter.embedding.engine.FlutterEngine { *; }
+-keep class io.flutter.plugins.GeneratedPluginRegistrant { *; }


### PR DESCRIPTION
## Summary
- enable release build shrinking in `mobile/android/app`
- add a default ProGuard ruleset for Flutter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889030bd85c8320855e2d6aaf32bc6f